### PR TITLE
KEYS patterns and no arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +131,7 @@ dependencies = [
  "chrono",
  "knowsql_bitcask",
  "knowsql_parser",
+ "regex",
  "serde",
  "toml",
  "tracing",
@@ -237,6 +247,35 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "serde"

--- a/crates/knowsql_parser/src/command.rs
+++ b/crates/knowsql_parser/src/command.rs
@@ -4,7 +4,7 @@ pub enum Command<'a> {
     Command(SubCommand),
     Echo(&'a str),
     Get(&'a str),
-    Keys(&'a str),
+    Keys(Option<&'a str>),
     Set(&'a str, &'a str),
     Ping,
     Quit,

--- a/crates/knowsql_parser/src/command.rs
+++ b/crates/knowsql_parser/src/command.rs
@@ -25,7 +25,7 @@ impl Command<'_> {
             ),
             ("ECHO", &["Returns message."]),
             ("GET", &["Get the value of key."]),
-            ("KEYS", &["Get all keys matching pattern."]),
+            ("KEYS", &["Get all keys matching a regex pattern."]),
             ("SET", &["Set the value of key."]),
             ("PING", &["Pong."]),
             ("QUIT", &["Ask the server to close the connection."]),

--- a/crates/knowsql_parser/src/resp2.rs
+++ b/crates/knowsql_parser/src/resp2.rs
@@ -24,8 +24,9 @@ pub fn parse_command(input: &[u8]) -> IResult<&[u8], Command> {
             [resp2::Data::BulkString("SET"), resp2::Data::BulkString(key), resp2::Data::BulkString(value)] => {
                 Ok((remaining, Command::Set(key, value)))
             }
+            [resp2::Data::BulkString("KEYS")] => Ok((remaining, Command::Keys(None))),
             [resp2::Data::BulkString("KEYS"), resp2::Data::BulkString(pattern)] => {
-                Ok((remaining, Command::Keys(pattern)))
+                Ok((remaining, Command::Keys(Some(pattern))))
             }
             [resp2::Data::BulkString("PING")] => Ok((remaining, Command::Ping)),
             [resp2::Data::BulkString("QUIT")] => Ok((remaining, Command::Quit)),

--- a/crates/knowsql_parser/src/simple.rs
+++ b/crates/knowsql_parser/src/simple.rs
@@ -34,13 +34,19 @@ fn parse_get(input: &[u8]) -> IResult<&[u8], Command> {
     ))
 }
 
-fn parse_keys(input: &[u8]) -> IResult<&[u8], Command> {
+fn parse_keys_no_pattern(input: &[u8]) -> IResult<&[u8], Command> {
     let (input, _) = tag_no_case("keys")(input)?;
+    Ok((input, Command::Keys(None)))
+}
+
+fn parse_keys_with_pattern(input: &[u8]) -> IResult<&[u8], Command> {
+    let (input, _) = tag_no_case("keys")(input)?;
+
     let (input, _) = tag(" ")(input)?;
     let (input, pattern) = alphanumeric1(input)?;
     Ok((
         input,
-        Command::Keys(std::str::from_utf8(pattern).expect("pattern is valid utf8 string")),
+        Command::Keys(Some(std::str::from_utf8(pattern).expect("pattern is valid utf8 string"))),
     ))
 }
 
@@ -75,7 +81,8 @@ pub fn parse_command(input: &[u8]) -> IResult<&[u8], Command> {
             parse_db_size,
             parse_get,
             parse_echo,
-            parse_keys,
+            parse_keys_with_pattern,
+            parse_keys_no_pattern,
             parse_set,
             parse_ping,
             parse_quit,

--- a/knowsql/Cargo.toml
+++ b/knowsql/Cargo.toml
@@ -12,3 +12,4 @@ serde = { workspace = true, features = ["derive"] }
 toml = { workspace = true }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+regex = "1.10.4"

--- a/knowsql/src/main.rs
+++ b/knowsql/src/main.rs
@@ -136,8 +136,12 @@ fn handle_client(mut stream: TcpStream, bitcask: Arc<Mutex<BitCask>>) {
                     };
 
                     let keys = bitcask.lock().unwrap().keys();
-                    let response =
-                        Data::Array(keys.iter().filter(|key| re.is_match(key)).map(|key| Data::BulkString(key)).collect());
+                    let response = Data::Array(
+                        keys.iter()
+                            .filter(|key| re.is_match(key))
+                            .map(|key| Data::BulkString(key))
+                            .collect(),
+                    );
 
                     let resp = response.as_str().expect("constructed from static values");
 


### PR DESCRIPTION
Allow `KEYS` to be provided a regex pattern, and allow `KEYS` to be executed without any arguments.